### PR TITLE
chore: increase browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hasl-departure-card",
   "version": "3.4.2",
   "description": "HASL Departure Lovelace Card",
+  "browserslist": "ios >= 12, android >= 5, last 2 versions, > 0.5%, not dead",
   "source": "src/index.ts",
   "module": "dist/hasl4-departure-card.js",
   "targets": {


### PR DESCRIPTION
To make this card work on an old iPad, for example, version 12 of iOS.

More info here: https://browsersl.ist/#q=ios+%3E%3D+12%2C+android+%3E%3D+5%2C+last+2+versions%2C+%3E+0.5%25%2C+not+dead

